### PR TITLE
Fix spelling error in Tied MVG classifier assumptions

### DIFF
--- a/exams/2024_09_11/2024_09_11_answer_1_LDA_TIED_MVG.md
+++ b/exams/2024_09_11/2024_09_11_answer_1_LDA_TIED_MVG.md
@@ -39,7 +39,7 @@
 
 * **Model formulation & assumptions**:
   This is a **generative model**. Each class is modeled as a **Multivariate Gaussian with its own mean** but a **tied
-  covariance matrix**, assuming data $x \in R^d$ and for each class $c$:
+  covariance matrix**, assuming data $x \in R^d$, indipendent and identically distributed and for each class $c$:
 
   $$
   X|C=c \sim \mathcal{N}(\mu_c, \Sigma), \quad \Sigma \text{ shared across classes}.


### PR DESCRIPTION
Clarified assumptions for Tied MVG classifier by correcting 'independent' spelling.

Verifica di chat:
Ottima osservazione! ✅
Sì, nel **tied MVG classifier** assumiamo implicitamente che i campioni siano **i.i.d. (independent and identically distributed)**.

Infatti, quando stimiamo i parametri (media e covarianza) con la **massima verosimiglianza**, usiamo la funzione di verosimiglianza del dataset che si scrive come prodotto delle densità dei singoli campioni:

$$
\mathcal{L}(\mu_c, \Sigma) = \prod_{i=1}^N f(x_i | C_i = c; \mu_c, \Sigma) $$

Questa fattorizzazione è valida **solo se i campioni sono indipendenti**. Inoltre, assumiamo che ogni campione sia distribuito secondo la stessa legge (identically distributed), cioè $x_i | C=c \sim \mathcal{N}(\mu_c, \Sigma)$ per tutti gli $i$.

👉 Quindi sì: per costruire e stimare il **tied MVG classifier**, i dati devono essere considerati **i.i.d.**.